### PR TITLE
Removed deprecated methods

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,2 @@
 preset: symfony
+disabled: [simplified_null_return, single_line_class_definition]

--- a/AutoRouteManager.php
+++ b/AutoRouteManager.php
@@ -74,7 +74,7 @@ class AutoRouteManager
         $this->collectionBuilder->build($uriContextCollection);
 
         foreach ($uriContextCollection->getUriContexts() as $uriContext) {
-            $subject = $uriContextCollection->getSubjectObject();
+            $subject = $uriContextCollection->getSubject();
 
             if (null !== $uriContext->getLocale()) {
                 $translatedSubject = $this->adapter->translateObject($subject, $uriContext->getLocale());
@@ -83,7 +83,7 @@ class AutoRouteManager
                     @trigger_error('AdapterInterface::translateObject() has to return the subject as of version 1.1, support for by reference will be removed in 2.0.', E_USER_DEPRECATED);
                 } else {
                     if ($translatedSubject !== $subject) {
-                        $uriContext->setTranslatedSubjectObject($translatedSubject);
+                        $uriContext->setTranslatedSubject($translatedSubject);
                     }
                 }
             }
@@ -137,7 +137,7 @@ class AutoRouteManager
      */
     private function handleExistingRoute($existingRoute, $uriContext)
     {
-        $isSameContent = $this->adapter->compareAutoRouteContent($existingRoute, $uriContext->getSubjectObject());
+        $isSameContent = $this->adapter->compareAutoRouteContent($existingRoute, $uriContext->getSubject());
 
         if ($isSameContent) {
             $autoRoute = $existingRoute;

--- a/DefunctRouteHandler/DelegatingDefunctRouteHandler.php
+++ b/DefunctRouteHandler/DelegatingDefunctRouteHandler.php
@@ -48,8 +48,8 @@ class DelegatingDefunctRouteHandler implements DefunctRouteHandlerInterface
      */
     public function handleDefunctRoutes(UriContextCollection $uriContextCollection)
     {
-        $subject = $uriContextCollection->getSubjectObject();
-        $realClassName = $this->adapter->getRealClassName(get_class($uriContextCollection->getSubjectObject()));
+        $subject = $uriContextCollection->getSubject();
+        $realClassName = $this->adapter->getRealClassName(get_class($uriContextCollection->getSubject()));
         $metadata = $this->metadataFactory->getMetadataForClass($realClassName);
 
         $defunctRouteHandlerConfig = $metadata->getDefunctRouteHandler();

--- a/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
+++ b/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
@@ -36,7 +36,7 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
 
         foreach ($referringAutoRouteCollection as $referringAutoRoute) {
             if (false === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {
-                $newRoute = $uriContextCollection->getAutoRouteByTag($referringAutoRoute->getAutoRouteTag());
+                $newRoute = $uriContextCollection->getAutoRouteByLocale($referringAutoRoute->getLocale());
 
                 if (null === $newRoute) {
                     continue;

--- a/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
+++ b/DefunctRouteHandler/LeaveRedirectDefunctRouteHandler.php
@@ -32,7 +32,7 @@ class LeaveRedirectDefunctRouteHandler implements DefunctRouteHandlerInterface
      */
     public function handleDefunctRoutes(UriContextCollection $uriContextCollection)
     {
-        $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubjectObject());
+        $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubject());
 
         foreach ($referringAutoRouteCollection as $referringAutoRoute) {
             if (false === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {

--- a/DefunctRouteHandler/RemoveDefunctRouteHandler.php
+++ b/DefunctRouteHandler/RemoveDefunctRouteHandler.php
@@ -39,7 +39,7 @@ class RemoveDefunctRouteHandler implements DefunctRouteHandlerInterface
 
         foreach ($referringAutoRouteCollection as $referringAutoRoute) {
             if (false === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {
-                $newRoute = $uriContextCollection->getAutoRouteByTag($referringAutoRoute->getAutoRouteTag());
+                $newRoute = $uriContextCollection->getAutoRouteByLocale($referringAutoRoute->getLocale());
 
                 if (null !== $newRoute) {
                     $this->adapter->migrateAutoRouteChildren($referringAutoRoute, $newRoute);

--- a/DefunctRouteHandler/RemoveDefunctRouteHandler.php
+++ b/DefunctRouteHandler/RemoveDefunctRouteHandler.php
@@ -35,7 +35,7 @@ class RemoveDefunctRouteHandler implements DefunctRouteHandlerInterface
      */
     public function handleDefunctRoutes(UriContextCollection $uriContextCollection)
     {
-        $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubjectObject());
+        $referringAutoRouteCollection = $this->adapter->getReferringAutoRoutes($uriContextCollection->getSubject());
 
         foreach ($referringAutoRouteCollection as $referringAutoRoute) {
             if (false === $uriContextCollection->containsAutoRoute($referringAutoRoute)) {

--- a/Model/AutoRouteInterface.php
+++ b/Model/AutoRouteInterface.php
@@ -34,19 +34,18 @@ interface AutoRouteInterface extends RouteObjectInterface
     const TYPE_REDIRECT = 'cmf_routing_auto.redirect';
 
     /**
-     * Set a tag which can be used by a database implementation
-     * to distinguish a route from other routes as required.
+     * Set a locale related to this auto route.
      *
-     * @param string $tag
+     * @param string $locale
      */
-    public function setAutoRouteTag($tag);
+    public function setLocale($locale);
 
     /**
-     * Return the auto route tag.
+     * Return the locale.
      *
      * @return string
      */
-    public function getAutoRouteTag();
+    public function getLocale();
 
     /**
      * Set the auto route mode.

--- a/Tests/Unit/AutoRouteManagerTest.php
+++ b/Tests/Unit/AutoRouteManagerTest.php
@@ -77,7 +77,7 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
         $this->context2->getLocale()->willReturn('de');
         $this->adapter->translateObject($this->subject, 'fr')->willReturn($translatedSubject)->shouldBeCalled();
         $this->adapter->translateObject($this->subject, 'de')->willReturn($this->subject)->shouldBeCalled();
-        $this->context1->setTranslatedSubjectObject($this->subject)->shouldBeCalled();
+        $this->context1->setTranslatedSubject($this->subject)->shouldBeCalled();
 
         $this->manager->buildUriContextCollection($this->collection->reveal());
     }
@@ -89,7 +89,7 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
             $this->context1->reveal(),
             $this->context2->reveal(),
         ));
-        $this->collection->getSubjectObject()->willReturn($this->subject);
+        $this->collection->getSubject()->willReturn($this->subject);
 
         for ($index = 1; $index <= 2; ++$index) {
             $contextVar = 'context'.$index;
@@ -97,7 +97,7 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
             $autoRouteVar = 'autoRoute'.$index;
 
             $this->uriGenerator->generateUri($this->{$contextVar}->reveal())->willReturn($uri);
-            $this->{$contextVar}->getSubjectObject()->willReturn($this->subject);
+            $this->{$contextVar}->getSubject()->willReturn($this->subject);
             $this->{$contextVar}->setUri($uri)->shouldBeCalled();
 
             $this->adapter->findRouteForUri($uri, $this->{$contextVar})->willReturn(null);
@@ -121,11 +121,11 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
         $this->collection->getUriContexts()->willReturn(array(
             $this->context1->reveal(),
         ));
-        $this->collection->getSubjectObject()->willReturn($this->subject);
+        $this->collection->getSubject()->willReturn($this->subject);
         $this->uriGenerator->generateUri($this->context1->reveal())->willReturn($uri);
         $this->context1->setUri($uri)->shouldBeCalled();
         $this->context1->getLocale()->willReturn(null);
-        $this->context1->getSubjectObject()->willReturn($this->subject);
+        $this->context1->getSubject()->willReturn($this->subject);
         $this->adapter->findRouteForUri($uri, $this->context1)->willReturn(
             $this->autoRoute1->reveal()
         );
@@ -136,7 +136,7 @@ class AutoRouteManagerTest extends \PHPUnit_Framework_TestCase
             $this->subject
         )->willReturn($sameContent);
 
-        $this->context1->getSubjectObject()->willReturn($this->subject);
+        $this->context1->getSubject()->willReturn($this->subject);
 
         if ($sameContent) {
             $this->autoRoute1->setType(AutoRouteInterface::TYPE_PRIMARY)

--- a/Tests/Unit/DefunctRouteHandler/DelegatingDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/DelegatingDefunctRouteHandlerTest.php
@@ -30,7 +30,7 @@ class DelegatingDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         $this->metadata = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Mapping\ClassMetadata');
         $this->delegatedHandler = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface');
 
-        $this->subjectObject = new \stdClass();
+        $this->subject = new \stdClass();
 
         $this->delegatingDefunctRouteHandler = new DelegatingDefunctRouteHandler(
             $this->metadataFactory->reveal(),
@@ -42,7 +42,7 @@ class DelegatingDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleDefunctRoutes()
     {
-        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
+        $this->uriContextCollection->getSubject()->willReturn($this->subject);
         $this->adapter->getRealClassName('stdClass')->willReturn('stdClass');
         $this->metadataFactory->getMetadataForClass('stdClass')->willReturn($this->metadata);
         $this->metadata->getDefunctRouteHandler()->willReturn(array(

--- a/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
@@ -44,8 +44,8 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         $this->uriContextCollection->containsAutoRoute($this->route2->reveal())->willReturn(false);
         $this->uriContextCollection->containsAutoRoute($this->route3->reveal())->willReturn(true);
 
-        $this->route2->getAutoRouteTag()->willReturn('fr');
-        $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn($this->route4);
+        $this->route2->getLocale()->willReturn('fr');
+        $this->uriContextCollection->getAutoRouteByLocale('fr')->willReturn($this->route4);
 
         $this->adapter->createRedirectRoute($this->route2->reveal(), $this->route4->reveal())->shouldBeCalled();
 
@@ -61,8 +61,8 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         ));
         $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(false);
 
-        $this->route1->getAutoRouteTag()->willReturn('fr');
-        $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn(null);
+        $this->route1->getLocale()->willReturn('fr');
+        $this->uriContextCollection->getAutoRouteByLocale('fr')->willReturn(null);
 
         $this->adapter->createRedirectRoute($this->route2->reveal(), $this->route4->reveal())->shouldNotBeCalled();
 

--- a/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/LeaveRedirectDefunctRouteHandlerTest.php
@@ -27,7 +27,7 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         $this->route3 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
         $this->route4 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
 
-        $this->subjectObject = new \stdClass();
+        $this->subject = new \stdClass();
 
         $this->handler = new LeaveRedirectDefunctRouteHandler(
             $this->adapter->reveal()
@@ -36,8 +36,8 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testLeaveRedirect()
     {
-        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
-        $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
+        $this->uriContextCollection->getSubject()->willReturn($this->subject);
+        $this->adapter->getReferringAutoRoutes($this->subject)->willReturn(array(
             $this->route1, $this->route2,
         ));
         $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(true);
@@ -55,8 +55,8 @@ class LeaveRedirectDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testLeaveDirectNoTranslation()
     {
-        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
-        $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
+        $this->uriContextCollection->getSubject()->willReturn($this->subject);
+        $this->adapter->getReferringAutoRoutes($this->subject)->willReturn(array(
             $this->route1,
         ));
         $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(false);

--- a/Tests/Unit/DefunctRouteHandler/RemoveDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/RemoveDefunctRouteHandlerTest.php
@@ -27,7 +27,7 @@ class RemoveDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         $this->route3 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
         $this->route4 = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
 
-        $this->subjectObject = new \stdClass();
+        $this->subject = new \stdClass();
 
         $this->handler = new RemoveDefunctRouteHandler(
             $this->adapter->reveal()
@@ -36,8 +36,8 @@ class RemoveDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleDefunctRoutes()
     {
-        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
-        $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
+        $this->uriContextCollection->getSubject()->willReturn($this->subject);
+        $this->adapter->getReferringAutoRoutes($this->subject)->willReturn(array(
             $this->route1, $this->route2,
         ));
         $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(true);
@@ -55,8 +55,8 @@ class RemoveDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
     public function testHandleDefunctRouteWithoutMigrateDueToNotExistingDestination()
     {
-        $this->uriContextCollection->getSubjectObject()->willReturn($this->subjectObject);
-        $this->adapter->getReferringAutoRoutes($this->subjectObject)->willReturn(array(
+        $this->uriContextCollection->getSubject()->willReturn($this->subject);
+        $this->adapter->getReferringAutoRoutes($this->subject)->willReturn(array(
             $this->route1,
         ));
 

--- a/Tests/Unit/DefunctRouteHandler/RemoveDefunctRouteHandlerTest.php
+++ b/Tests/Unit/DefunctRouteHandler/RemoveDefunctRouteHandlerTest.php
@@ -44,8 +44,8 @@ class RemoveDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
         $this->uriContextCollection->containsAutoRoute($this->route2->reveal())->willReturn(false);
         $this->uriContextCollection->containsAutoRoute($this->route3->reveal())->willReturn(true);
 
-        $this->route2->getAutoRouteTag()->willReturn('fr');
-        $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn($this->route4);
+        $this->route2->getLocale()->willReturn('fr');
+        $this->uriContextCollection->getAutoRouteByLocale('fr')->willReturn($this->route4);
 
         $this->adapter->migrateAutoRouteChildren($this->route2->reveal(), $this->route4->reveal())->shouldBeCalled();
         $this->adapter->removeAutoRoute($this->route2->reveal())->shouldBeCalled();
@@ -62,8 +62,8 @@ class RemoveDefunctRouteHandlerTest extends \PHPUnit_Framework_TestCase
 
         $this->uriContextCollection->containsAutoRoute($this->route1->reveal())->willReturn(false);
 
-        $this->route1->getAutoRouteTag()->willReturn('fr');
-        $this->uriContextCollection->getAutoRouteByTag('fr')->willReturn(null);
+        $this->route1->getLocale()->willReturn('fr');
+        $this->uriContextCollection->getAutoRouteByLocale('fr')->willReturn(null);
 
         $this->adapter->removeAutoRoute($this->route1->reveal())->shouldBeCalled();
 

--- a/Tests/Unit/TokenProvider/ContentDateTimeProviderTest.php
+++ b/Tests/Unit/TokenProvider/ContentDateTimeProviderTest.php
@@ -53,7 +53,7 @@ class ContentDateTimeProviderTest extends \PHPUnit_Framework_TestCase
             'slugify' => true,
         ), $options);
 
-        $this->uriContext->getSubjectObject()->willReturn($this->article);
+        $this->uriContext->getSubject()->willReturn($this->article);
         $this->article->getDate()->willReturn(new \DateTime('2014-10-09'));
 
         $res = $this->provider->provideValue($this->uriContext->reveal(), $options);

--- a/Tests/Unit/TokenProvider/ContentMethodProviderTest.php
+++ b/Tests/Unit/TokenProvider/ContentMethodProviderTest.php
@@ -60,7 +60,7 @@ class ContentMethodProviderTest extends \PHPUnit_Framework_TestCase
     public function testGetValue($options, $methodExists = false)
     {
         $method = $options['method'];
-        $this->uriContext->getSubjectObject()->willReturn($this->article);
+        $this->uriContext->getSubject()->willReturn($this->article);
 
         if (!$methodExists) {
             $this->setExpectedException(

--- a/Tests/Unit/UriContextCollectionBuilderTest.php
+++ b/Tests/Unit/UriContextCollectionBuilderTest.php
@@ -57,7 +57,7 @@ class UriContextCollectionBuilderTest extends \PHPUnit_Framework_TestCase
             )),
         );
 
-        $this->collection->getSubjectObject()->willReturn($this->subject);
+        $this->collection->getSubject()->willReturn($this->subject);
         $this->adapter->getRealClassName('stdClass')->willReturn('STDCLASS');
         $this->metadataFactory->getMetadataForClass('STDCLASS')->willReturn($this->metadata->reveal());
         $this->adapter->getLocales($this->subject)->willReturn($locales);

--- a/Tests/Unit/UriContextCollectionTest.php
+++ b/Tests/Unit/UriContextCollectionTest.php
@@ -19,7 +19,7 @@ class UriContextCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->subjectObject = new \stdClass();
+        $this->subject = new \stdClass();
 
         for ($i = 1; $i <= 3; ++$i) {
             $this->{'autoRoute'.$i} = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
@@ -27,12 +27,12 @@ class UriContextCollectionTest extends \PHPUnit_Framework_TestCase
             $this->{'uriContext'.$i}->getAutoRoute()->willReturn($this->{'autoRoute'.$i});
         }
 
-        $this->uriContextCollection = new UriContextCollection($this->subjectObject);
+        $this->uriContextCollection = new UriContextCollection($this->subject);
     }
 
-    public function testGetSubjectObject()
+    public function testGetSubject()
     {
-        $this->assertEquals($this->subjectObject, $this->uriContextCollection->getSubjectObject());
+        $this->assertEquals($this->subject, $this->uriContextCollection->getSubject());
     }
 
     public function testCreateUriContext()

--- a/Tests/Unit/UriContextTest.php
+++ b/Tests/Unit/UriContextTest.php
@@ -19,13 +19,13 @@ class UriContextTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->subjectObject = new \stdClass();
+        $this->subject = new \stdClass();
         $this->autoRoute = $this->prophesize('Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface');
     }
 
     public function testGetSet()
     {
-        $uriContext = new UriContext($this->subjectObject, '/uri/', array('default1' => 'value1'), array('token'), array('conflict'), 'fr');
+        $uriContext = new UriContext($this->subject, '/uri/', array('default1' => 'value1'), array('token'), array('conflict'), 'fr');
 
         // locales
         $this->assertEquals('fr', $uriContext->getLocale());
@@ -36,17 +36,17 @@ class UriContextTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/foo/bar', $uriContext->getUri());
 
         // subject object
-        $this->assertEquals($this->subjectObject, $uriContext->getSubjectObject());
+        $this->assertEquals($this->subject, $uriContext->getSubject());
 
         // auto route
         $uriContext->setAutoRoute($this->autoRoute);
         $this->assertEquals($this->autoRoute, $uriContext->getAutoRoute());
 
         // the translated subject should be initially set as the original subject
-        $this->assertSame($this->subjectObject, $uriContext->getTranslatedSubjectObject());
+        $this->assertSame($this->subject, $uriContext->getTranslatedSubject());
         $transSubject = new \stdClass();
-        $uriContext->setTranslatedSubjectObject($transSubject);
-        $this->assertSame($transSubject, $uriContext->getTranslatedSubjectObject());
+        $uriContext->setTranslatedSubject($transSubject);
+        $this->assertSame($transSubject, $uriContext->getTranslatedSubject());
 
         // uri schema
         $this->assertEquals('/uri/', $uriContext->getUriSchema());

--- a/Tests/Unit/UriGeneratorTest.php
+++ b/Tests/Unit/UriGeneratorTest.php
@@ -220,7 +220,7 @@ class UriGeneratorTest extends \PHPUnit_Framework_TestCase
         }
 
         $document = new \stdClass();
-        $this->uriContext->getSubjectObject()->willReturn($document);
+        $this->uriContext->getSubject()->willReturn($document);
         $this->uriContext->getUri()->willReturn($uriSchema);
         $this->uriContext->getTokenProviderConfigs()
             ->willReturn($tokenProviderConfigs);

--- a/TokenProvider/BaseContentMethodProvider.php
+++ b/TokenProvider/BaseContentMethodProvider.php
@@ -22,7 +22,7 @@ abstract class BaseContentMethodProvider implements TokenProviderInterface
      */
     public function provideValue(UriContext $uriContext, $options)
     {
-        $object = $uriContext->getSubjectObject();
+        $object = $uriContext->getSubject();
         $method = $options['method'];
         $this->checkMethodExists($object, $method);
 

--- a/TokenProvider/ContentDateTimeProvider.php
+++ b/TokenProvider/ContentDateTimeProvider.php
@@ -23,7 +23,7 @@ class ContentDateTimeProvider extends BaseContentMethodProvider
     {
         if (!$date instanceof \DateTime) {
             throw new \RuntimeException(sprintf('Method %s:%s must return an instance of DateTime.',
-                get_class($uriContext->getSubjectObject()),
+                get_class($uriContext->getSubject()),
                 $options['method']
             ));
         }

--- a/TokenProvider/ContentDateTimeProvider.php
+++ b/TokenProvider/ContentDateTimeProvider.php
@@ -40,14 +40,6 @@ class ContentDateTimeProvider extends BaseContentMethodProvider
 
         $optionsResolver->setDefault('date_format', 'Y-m-d');
 
-        $slugifyNormalizer = function ($options, $value) {
-            if (null !== $value) {
-                @trigger_error('The slugify option of '.__CLASS__.' is deprecated as of version 1.1 and will be removed in 2.0. Using it has no effect.', E_USER_DEPRECATED);
-            }
-        };
-
         $optionsResolver->setAllowedTypes('date_format', 'string');
-        $optionsResolver->setDefined('slugify');
-        $optionsResolver->setNormalizer('slugify', $slugifyNormalizer);
     }
 }

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -1,0 +1,13 @@
+# Upgrade from 1.2 to 2.0
+
+## Auto Routes
+
+ * The `setAutoRouteTag()`/`getAutoRouteTag()` methods are renamed to
+   `setLocale()`/`getLocale()`.
+
+ * The `getAutoRouteByTag()` is renamed to `getAutoRouteByLocale()`.
+
+## Uri Context
+
+ * The `subjectObject` and `translatedSubjectObject` with their related methods
+   are renamed to `subject` and `translatedSubject`.

--- a/UriContext.php
+++ b/UriContext.php
@@ -18,7 +18,7 @@ namespace Symfony\Cmf\Component\RoutingAuto;
  */
 class UriContext
 {
-    protected $subjectObject;
+    protected $subject;
     protected $translatedSubject;
     protected $locale;
     protected $uri;
@@ -30,15 +30,15 @@ class UriContext
     protected $defaults;
 
     public function __construct(
-        $subjectObject,
+        $subject,
         $uriSchema,
         array $defaults,
         array $tokenProviderConfigs,
         array $conflictResolverConfig,
         $locale
     ) {
-        $this->subjectObject = $subjectObject;
-        $this->translatedSubject = $subjectObject;
+        $this->subject = $subject;
+        $this->translatedSubject = $subject;
         $this->locale = $locale;
         $this->uriSchema = $uriSchema;
         $this->tokenProviderConfigs = $tokenProviderConfigs;
@@ -61,9 +61,9 @@ class UriContext
      *
      * @return object
      */
-    public function getSubjectObject()
+    public function getSubject()
     {
-        return $this->subjectObject;
+        return $this->subject;
     }
 
     /**
@@ -72,7 +72,7 @@ class UriContext
      *
      * @return object
      */
-    public function getTranslatedSubjectObject()
+    public function getTranslatedSubject()
     {
         return $this->translatedSubject;
     }
@@ -82,7 +82,7 @@ class UriContext
      *
      * @param object $translatedSubject
      */
-    public function setTranslatedSubjectObject($translatedSubject)
+    public function setTranslatedSubject($translatedSubject)
     {
         $this->translatedSubject = $translatedSubject;
     }

--- a/UriContextCollection.php
+++ b/UriContextCollection.php
@@ -113,19 +113,19 @@ class UriContextCollection
     /**
      * Get an auto route by its tag (e.g. the locale).
      *
-     * @param mixed $tag
+     * @param string $locale
      *
      * @return AutoRouteInterface|null
      */
-    public function getAutoRouteByTag($tag)
+    public function getAutoRouteByLocale($locale)
     {
         foreach ($this->uriContexts as $uriContext) {
             $autoRoute = $uriContext->getAutoRoute();
-            if ($tag === $autoRoute->getAutoRouteTag()) {
+            if ($locale === $autoRoute->getAutoRouteLocale()) {
                 return $autoRoute;
             }
         }
 
-        return;
+        return null;
     }
 }

--- a/UriContextCollection.php
+++ b/UriContextCollection.php
@@ -18,25 +18,25 @@ class UriContextCollection
     /**
      * @var object
      */
-    protected $subjectObject;
+    protected $subject;
     protected $uriContexts = array();
 
     /**
-     * @param object $subjectObject Subject for URL generation
+     * @param object $subject Subject for URL generation
      */
-    public function __construct($subjectObject)
+    public function __construct($subject)
     {
-        $this->subjectObject = $subjectObject;
+        $this->subject = $subject;
     }
 
     /**
      * Set the subject for URL generation.
      *
-     * @param object $subjectObject
+     * @param object $subject
      */
-    public function setSubjectObject($subjectObject)
+    public function setSubject($subject)
     {
-        $this->subjectObject = $subjectObject;
+        $this->subject = $subject;
     }
 
     /**
@@ -45,9 +45,9 @@ class UriContextCollection
      *
      * @return object
      */
-    public function getSubjectObject()
+    public function getSubject()
     {
-        return $this->subjectObject;
+        return $this->subject;
     }
 
     /**
@@ -65,7 +65,7 @@ class UriContextCollection
         $locale
     ) {
         $uriContext = new UriContext(
-            $this->getSubjectObject(),
+            $this->getSubject(),
             $uriSchema,
             $defaults,
             $tokenProviderConfigs,

--- a/UriContextCollectionBuilder.php
+++ b/UriContextCollectionBuilder.php
@@ -44,8 +44,8 @@ class UriContextCollectionBuilder
      */
     public function build(UriContextCollection $uriContextCollection)
     {
-        $subjectObject = $uriContextCollection->getSubjectObject();
-        $realClassName = $this->adapter->getRealClassName(get_class($subjectObject));
+        $subject = $uriContextCollection->getSubject();
+        $realClassName = $this->adapter->getRealClassName(get_class($subject));
         $metadata = $this->metadataFactory->getMetadataForClass($realClassName);
 
         // TODO: This is where we will call $metadata->getUriSchemas() which will return an
@@ -53,7 +53,7 @@ class UriContextCollectionBuilder
         $definitions = $metadata->getAutoRouteDefinitions();
 
         foreach ($definitions as $definition) {
-            $locales = $this->adapter->getLocales($subjectObject) ?: array(null);
+            $locales = $this->adapter->getLocales($subject) ?: array(null);
             foreach ($locales as $locale) {
                 // create and add uri context to stack
                 $uriContext = $uriContextCollection->createUriContext(

--- a/UriGenerator.php
+++ b/UriGenerator.php
@@ -90,7 +90,7 @@ class UriGenerator implements UriGeneratorInterface
         if (substr($uri, 0, 1) !== '/') {
             throw new \InvalidArgumentException(sprintf(
                 'Generated non-absolute URI "%s" for object "%s"',
-                $uri, get_class($uriContext->getSubjectObject())
+                $uri, get_class($uriContext->getSubject())
             ));
         }
 


### PR DESCRIPTION
fix #79, #81, #44 

The method renamings from #44 were applied immediately. We might want to release 1.1.1 that triggers deprecations for these? (focus point for the RC phase)