### PR TITLE
Correct typo in @cffb517

### DIFF
--- a/UriContextCollection.php
+++ b/UriContextCollection.php
@@ -121,7 +121,7 @@ class UriContextCollection
     {
         foreach ($this->uriContexts as $uriContext) {
             $autoRoute = $uriContext->getAutoRoute();
-            if ($locale === $autoRoute->getAutoRouteLocale()) {
+            if ($locale === $autoRoute->getLocale()) {
                 return $autoRoute;
             }
         }


### PR DESCRIPTION
Typo was revealed by a test failure on my other pull request on the
symfony-cmf/routing-auto-bundle repository.
See symfony-cmf/routing-auto-bundle#192.
Caused by @cffb517190c75b92672d0dbd45369f34af5d135b.