### PR TITLE
Fixed warning about deprecated PHPUnit_Framework_TestCase::getMock() method

### DIFF
--- a/tests/Unit/ServiceRegistryTest.php
+++ b/tests/Unit/ServiceRegistryTest.php
@@ -23,9 +23,9 @@ class ServiceRegistryTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->serviceRegistry = new ServiceRegistry();
-        $this->tokenProvider = $this->getMock('Symfony\Cmf\Component\RoutingAuto\TokenProviderInterface');
-        $this->conflictResolver = $this->getMock('Symfony\Cmf\Component\RoutingAuto\ConflictResolverInterface');
-        $this->defunctRouteHandler = $this->getMock('Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface');
+        $this->tokenProvider = $this->createMock('Symfony\Cmf\Component\RoutingAuto\TokenProviderInterface');
+        $this->conflictResolver = $this->createMock('Symfony\Cmf\Component\RoutingAuto\ConflictResolverInterface');
+        $this->defunctRouteHandler = $this->createMock('Symfony\Cmf\Component\RoutingAuto\DefunctRouteHandlerInterface');
     }
 
     public function testRegistration()


### PR DESCRIPTION
It is deprecated in favor of createMock() since version 5.4.