### PR TITLE
Use PHPUnit from Composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
   
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
+before_script: vendor/bin/phpunit --version
+
 script: vendor/bin/phpunit
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
-script: phpunit
+script: vendor/bin/phpunit
 
 notifications:
   irc: "irc.freenode.org#symfony-cmf"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/yaml": "^2.8|^3.0",
         "symfony/dependency-injection": "^2.8|^3.0",
         "symfony/event-dispatcher": "^2.8|^3.0",
-        "phpunit/phpunit": "^5.7|^6.1"
+        "phpunit/phpunit": "^5.7"
    },
     "suggest": {
         "symfony/yaml": "To be able to load Yaml configuration files (^2.1|3.*)",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,9 @@
     "require-dev": {
         "symfony/yaml": "^2.8|^3.0",
         "symfony/dependency-injection": "^2.8|^3.0",
-        "symfony/event-dispatcher": "^2.8|^3.0"
-    },
+        "symfony/event-dispatcher": "^2.8|^3.0",
+        "phpunit/phpunit": "^5.7|^6.1"
+   },
     "suggest": {
         "symfony/yaml": "To be able to load Yaml configuration files (^2.1|3.*)",
         "symfony-cmf/routing-auto-bundle": "To integrate this lirbary with Symfony and the CMF",


### PR DESCRIPTION
As the Travis CI Linux distributions provide different PHPUnit versions when testing against different PHP versions, using PHPUnit from composer gives us control over the PHPUnit features available.

It is currently the source of failed test runs as many deprecated methods have been removed from PHPUnit 6.