### PR TITLE
Set Travis distribution to  Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-
+dist: trusty
 php:
   - 7.0
   - hhvm


### PR DESCRIPTION
As Ubuntu Precise is no more supported by HHVM, we need to use Ubuntu Trusty.
See travis-ci/travis-ci#7712.