### PR TITLE
Revert "Enable the new version of jms/metadata"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony-cmf/routing": "^1.2|^2.0",
         "symfony/options-resolver": "^2.8|^3.0",
         "symfony/config": "^2.8|^3.0",
-        "jms/metadata": "^1.5"
+        "jms/metadata": "1.5.*"
     },
     "require-dev": {
         "symfony/yaml": "^2.8|^3.0",


### PR DESCRIPTION
This reverts commit 3e584aef8f1bd2415d0dd7f6c23ca34b2167fa85.

Releasing this should fix https://github.com/symfony-cmf/routing-auto-bundle/pull/208