### PR TITLE
use locale of autoroute again

### DIFF
--- a/src/UriContextCollection.php
+++ b/src/UriContextCollection.php
@@ -19,6 +19,10 @@ use Symfony\Cmf\Component\RoutingAuto\Model\AutoRouteInterface;
 class UriContextCollection
 {
     protected $subject;
+
+    /**
+     * @var UriContext[]
+     */
     protected $uriContexts = [];
 
     /**
@@ -157,7 +161,7 @@ class UriContextCollection
         foreach ($this->uriContexts as $uriContext) {
             $autoRoute = $uriContext->getAutoRoute();
 
-            if (null !== $autoRoute && $locale === $uriContext->getLocale()) {
+            if (null !== $autoRoute && $locale === $autoRoute->getLocale()) {
                 return $autoRoute;
             }
         }


### PR DESCRIPTION
in #95 we changed to use the locale of the context over the locale of the route. this led to a regression in routing-auto-bundle, see https://github.com/symfony-cmf/routing-auto-bundle/pull/211