### PR TITLE
Allow ^1.5 of jms/metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony-cmf/routing": "^1.2|^2.0",
         "symfony/options-resolver": "^2.8|^3.0",
         "symfony/config": "^2.8|^3.0",
-        "jms/metadata": "1.5.*"
+        "jms/metadata": "^1.5"
     },
     "require-dev": {
         "symfony/yaml": "^2.8|^3.0",


### PR DESCRIPTION
#101 probably was not needed.

Revert "Revert "Enable the new version of jms/metadata""

This reverts commit 6b94396e4e7f81cf9d3e0152d53fc2783d9abb78.