### PR TITLE
.yaml files support

### DIFF
--- a/src/Mapping/Loader/XmlFileLoader.php
+++ b/src/Mapping/Loader/XmlFileLoader.php
@@ -209,7 +209,13 @@ class XmlFileLoader extends FileLoader
      */
     public function supports($resource, $type = null)
     {
-        return is_string($resource) && 'xml' === pathinfo($resource, PATHINFO_EXTENSION) && (!$type || 'xml' === $type);
+        if (!is_string($resource)) {
+            return false;
+        }
+
+        $extension = pathinfo($resource, PATHINFO_EXTENSION);
+
+        return 'xml' === $extension && (null === $type || 'xml' === $type);
     }
 
     protected function getParser()

--- a/src/Mapping/Loader/XmlFileLoader.php
+++ b/src/Mapping/Loader/XmlFileLoader.php
@@ -24,6 +24,7 @@ use Symfony\Component\Config\Util\XmlUtils;
 class XmlFileLoader extends FileLoader
 {
     const NAMESPACE_URI = 'http://cmf.symfony.com/schema/routing_auto';
+
     const SCHEMA_FILE = '/schema/auto-routing/auto-routing-1.0.xsd';
 
     /**

--- a/src/Mapping/Loader/YmlFileLoader.php
+++ b/src/Mapping/Loader/YmlFileLoader.php
@@ -181,7 +181,13 @@ class YmlFileLoader extends FileLoader
      */
     public function supports($resource, $type = null)
     {
-        return is_string($resource) && 'yml' === pathinfo($resource, PATHINFO_EXTENSION) && (!$type || 'yaml' === $type);
+        if (!is_string($resource)) {
+            return false;
+        }
+
+        $extension = pathinfo($resource, PATHINFO_EXTENSION);
+
+        return ('yml' === $extension || 'yaml' === $extension) && (null === $type || 'yaml' === $type);
     }
 
     protected function getParser()

--- a/tests/Resources/Fixtures/Article.php
+++ b/tests/Resources/Fixtures/Article.php
@@ -14,9 +14,13 @@ namespace Symfony\Cmf\Component\RoutingAuto\Tests\Resources\Fixtures;
 class Article
 {
     public $path;
+
     public $routes;
+
     public $title;
+
     public $locale;
+
     public $date;
 
     public function getTitle()

--- a/tests/Unit/Adapter/EventDispatchingAdapterTest.php
+++ b/tests/Unit/Adapter/EventDispatchingAdapterTest.php
@@ -207,6 +207,7 @@ class EventDispatchingAdapterTest extends \PHPUnit_Framework_TestCase
 class EventDispatchingAdapterSubscriber implements EventSubscriberInterface
 {
     public $createEvent;
+
     public $migrateEvent;
 
     public static function getSubscribedEvents()

--- a/tests/Unit/Mapping/Loader/XmlFileLoaderTest.php
+++ b/tests/Unit/Mapping/Loader/XmlFileLoaderTest.php
@@ -54,8 +54,21 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         return [
             ['foo.xml'],
             ['foo.yml', null, false],
+
             ['foo.xml', 'xml'],
             ['foo.xml', 'yaml', false],
+
+            ['foo.bar', null, false],
+            ['foo.bar', 'yaml', false],
+            ['foo.bar', 'xml', false],
+
+            ['foo', null, false],
+            ['foo', 'yaml', false],
+            ['foo', 'xml', false],
+
+            ['foo.yml', 'bar', false],
+            ['foo.xml', 'bar', false],
+            ['foo.bar', 'bar', false],
         ];
     }
 

--- a/tests/Unit/Mapping/Loader/YmlFileLoaderTest.php
+++ b/tests/Unit/Mapping/Loader/YmlFileLoaderTest.php
@@ -53,9 +53,12 @@ class YmlFileLoaderTest extends \PHPUnit_Framework_TestCase
     {
         return [
             ['foo.yml'],
+            ['foo.yaml'],
             ['foo.xml', null, false],
             ['foo.yml', 'yaml'],
+            ['foo.yaml', 'yaml'],
             ['foo.yml', 'xml', false],
+            ['foo.yaml', 'xml', false],
         ];
     }
 

--- a/tests/Unit/Mapping/Loader/YmlFileLoaderTest.php
+++ b/tests/Unit/Mapping/Loader/YmlFileLoaderTest.php
@@ -54,11 +54,27 @@ class YmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         return [
             ['foo.yml'],
             ['foo.yaml'],
+
             ['foo.xml', null, false],
+            ['foo.xml', 'yaml', false],
+
             ['foo.yml', 'yaml'],
             ['foo.yaml', 'yaml'],
+
             ['foo.yml', 'xml', false],
             ['foo.yaml', 'xml', false],
+
+            ['foo.bar', null, false],
+            ['foo.bar', 'yaml', false],
+            ['foo.bar', 'xml', false],
+
+            ['foo', null, false],
+            ['foo', 'yaml', false],
+            ['foo', 'xml', false],
+
+            ['foo.yml', 'bar', false],
+            ['foo.xml', 'bar', false],
+            ['foo.bar', 'bar', false],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | n/a
| License       | MIT
| Doc PR        | n/a

This PR adds support for loading `.yaml` files in addition to `.yml` files using the _YmlFileLoader_.

Some more test cases have been added to the _XmlFileLoader_ and _YmlFileLoader_ `supports` method.

The `supports` methods implementation on-liners have been refactored to a more readable form (in my opinion).