### PR TITLE
Fix type hinting from jms/metadata

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony-cmf/routing": "^1.2 || ^2.0",
         "symfony/options-resolver": "^2.8 || ^3.3 || ^4.0",
         "symfony/config": "^2.8 || ^3.3 || ^4.0",
-        "jms/metadata": "^1.5|^2.1"
+        "jms/metadata": "^2.1"
     },
     "require-dev": {
         "symfony/yaml": "^2.8 || ^3.3 || ^4.0",

--- a/src/Mapping/ClassMetadata.php
+++ b/src/Mapping/ClassMetadata.php
@@ -174,7 +174,7 @@ class ClassMetadata extends MergeableClassMetadata
      *
      * @param ClassMetadata $metadata
      */
-    public function merge(MergeableInterface $metadata)
+    public function merge(MergeableInterface $metadata): void
     {
         parent::merge($metadata);
 

--- a/src/Mapping/MetadataFactory.php
+++ b/src/Mapping/MetadataFactory.php
@@ -74,7 +74,7 @@ class MetadataFactory implements \IteratorAggregate, MetadataFactoryInterface
      *
      * @return ClassMetadata
      */
-    public function getMetadataForClass($class)
+    public function getMetadataForClass(string $class)
     {
         if (!isset($this->resolvedMetadatas[$class])) {
             $this->resolveMetadata($class);


### PR DESCRIPTION
The purpose of this PR is to provide compatibility with jms/metadata type hinting as version requirement has been upgraded recently.